### PR TITLE
Add Registered Depth Stream

### DIFF
--- a/include/realsense_gazebo_plugin/RealSensePlugin.h
+++ b/include/realsense_gazebo_plugin/RealSensePlugin.h
@@ -32,6 +32,7 @@ namespace gazebo
 {
 
   #define DEPTH_CAMERA_NAME "depth"
+  #define DEPTH_REGISTERED_CAMERA_NAME "depth_registered"
   #define COLOR_CAMERA_NAME "color"
   #define IRED1_CAMERA_NAME "ired1"
   #define IRED2_CAMERA_NAME "ired2"
@@ -54,7 +55,9 @@ namespace gazebo
     /// \brief Callback that publishes a received Depth Camera Frame as an
     /// ImageStamped
     /// message.
-    public: virtual void OnNewDepthFrame();
+    public: virtual void OnNewDepthFrame(std::vector<uint16_t> *depth_map,
+                                         const rendering::DepthCameraPtr cam,
+                                         const transport::PublisherPtr pub);
 
     /// \brief Callback that publishes a received Camera Frame as an
     /// ImageStamped message.
@@ -69,6 +72,9 @@ namespace gazebo
 
     /// \brief Pointer to the Depth Camera Renderer.
     protected: rendering::DepthCameraPtr depthCam;
+
+    /// \brief Pointer to the Registered Depth Camera Renderer.
+    protected: rendering::DepthCameraPtr depthRegisteredCam;
 
     /// \brief Pointer to the Color Camera Renderer.
     protected: rendering::CameraPtr colorCam;
@@ -85,8 +91,14 @@ namespace gazebo
     // \brief Store Real Sense depth map data.
     protected: std::vector<uint16_t> depthMap;
 
+    // \brief Store Real Sense depth map data.
+    protected: std::vector<uint16_t> depthRegisteredMap;
+
     /// \brief Pointer to the Depth Publisher.
     protected: transport::PublisherPtr depthPub;
+
+    /// \brief Pointer to the Depth Registered Publisher.
+    protected: transport::PublisherPtr depthRegisteredPub;
 
     /// \brief Pointer to the Color Publisher.
     protected: transport::PublisherPtr colorPub;
@@ -100,10 +112,13 @@ namespace gazebo
     /// \brief Pointer to the Depth Camera callback connection.
     protected: event::ConnectionPtr newDepthFrameConn;
 
-    /// \brief Pointer to the Depth Camera callback connection.
+    /// \brief Pointer to the Depth Registered Camera callback connection.
+    protected: event::ConnectionPtr newDepthRegisteredFrameConn;
+
+    /// \brief Pointer to the Infrered1 Camera callback connection.
     protected: event::ConnectionPtr newIred1FrameConn;
 
-    /// \brief Pointer to the Infrared Camera callback connection.
+    /// \brief Pointer to the Infrared2 Camera callback connection.
     protected: event::ConnectionPtr newIred2FrameConn;
 
     /// \brief Pointer to the Color Camera callback connection.

--- a/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
+++ b/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
@@ -30,7 +30,9 @@ namespace gazebo
 
     /// \brief Callback that publishes a received Depth Camera Frame as an
     /// ImageStamped message.
-    public: virtual void OnNewDepthFrame();
+    public: virtual void OnNewDepthFrame(std::vector<uint16_t> *depth_map,
+                                         const rendering::DepthCameraPtr cam,
+                                         const transport::PublisherPtr pub);
 
     /// \brief Callback that publishes a received Camera Frame as an
     /// ImageStamped message.
@@ -43,7 +45,7 @@ namespace gazebo
     ///  A node will be instantiated if it does not exist.
     protected: ros::NodeHandle* rosnode_;
     private: image_transport::ImageTransport* itnode_;
-    protected: image_transport::CameraPublisher color_pub_, ir1_pub_, ir2_pub_, depth_pub_;
+    protected: image_transport::CameraPublisher color_pub_, ir1_pub_, ir2_pub_, depth_pub_, depth_registered_pub_;
 
     /// \brief ROS image messages
     protected: sensor_msgs::Image image_msg_, depth_msg_;

--- a/src/RealSensePlugin.cpp
+++ b/src/RealSensePlugin.cpp
@@ -20,11 +20,13 @@
 #include <gazebo/sensors/sensors.hh>
 
 #define DEPTH_PUB_FREQ_HZ 60
+#define DEPTH_REGISTERED_PUB_FREQ_HZ 60
 #define COLOR_PUB_FREQ_HZ 60
 #define IRED1_PUB_FREQ_HZ 60
 #define IRED2_PUB_FREQ_HZ 60
 
 #define DEPTH_CAMERA_TOPIC "depth"
+#define DEPTH_REGISTERED_CAMERA_TOPIC "depth_registered"
 #define COLOR_CAMERA_TOPIC "color"
 #define IRED1_CAMERA_TOPIC "infrared"
 #define IRED2_CAMERA_TOPIC "infrared2"
@@ -39,6 +41,7 @@ using namespace gazebo;
 RealSensePlugin::RealSensePlugin()
 {
   this->depthCam = nullptr;
+  this->depthRegisteredCam = nullptr;
   this->ired1Cam = nullptr;
   this->ired2Cam = nullptr;
   this->colorCam = nullptr;
@@ -75,6 +78,9 @@ void RealSensePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   this->depthCam = std::dynamic_pointer_cast<sensors::DepthCameraSensor>(
                                 smanager->GetSensor(prefix+DEPTH_CAMERA_NAME))
                                 ->DepthCamera();
+  this->depthRegisteredCam = std::dynamic_pointer_cast<sensors::DepthCameraSensor>(
+                                smanager->GetSensor(prefix+DEPTH_REGISTERED_CAMERA_NAME))
+                                ->DepthCamera();
   this->ired1Cam = std::dynamic_pointer_cast<sensors::CameraSensor>(
                                 smanager->GetSensor(prefix+IRED1_CAMERA_NAME))
                                 ->Camera();
@@ -89,6 +95,12 @@ void RealSensePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   if (!this->depthCam)
   {
     std::cerr << "RealSensePlugin: Depth Camera has not been found"
+              << std::endl;
+    return;
+  }
+  if (!this->depthRegisteredCam)
+  {
+    std::cerr << "RealSensePlugin: Depth Registered Camera has not been found"
               << std::endl;
     return;
   }
@@ -122,6 +134,16 @@ void RealSensePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
               << std::endl;
     return;
   }
+  try
+  {
+    this->depthRegisteredMap.resize(this->depthRegisteredCam->ImageWidth() * this->depthRegisteredCam->ImageHeight());
+  }
+  catch (std::bad_alloc &e)
+  {
+    std::cerr << "RealSensePlugin: depthRegisteredMap allocation failed: " << e.what()
+              << std::endl;
+    return;
+  }
 
   // Setup Transport Node
   this->transportNode = transport::NodePtr(new transport::Node());
@@ -137,16 +159,25 @@ void RealSensePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
   this->depthPub = this->transportNode->Advertise<msgs::ImageStamped>(
           rsTopicRoot + DEPTH_CAMERA_TOPIC, 1, DEPTH_PUB_FREQ_HZ);
+  this->depthRegisteredPub = this->transportNode->Advertise<msgs::ImageStamped>(
+          rsTopicRoot + DEPTH_REGISTERED_CAMERA_TOPIC, 1, DEPTH_REGISTERED_PUB_FREQ_HZ);
   this->ired1Pub = this->transportNode->Advertise<msgs::ImageStamped>(
-          rsTopicRoot + IRED1_CAMERA_TOPIC, 1, DEPTH_PUB_FREQ_HZ);
+          rsTopicRoot + IRED1_CAMERA_TOPIC, 1, IRED1_PUB_FREQ_HZ);
   this->ired2Pub = this->transportNode->Advertise<msgs::ImageStamped>(
-          rsTopicRoot + IRED2_CAMERA_TOPIC, 1, DEPTH_PUB_FREQ_HZ);
+          rsTopicRoot + IRED2_CAMERA_TOPIC, 1, IRED2_PUB_FREQ_HZ);
   this->colorPub = this->transportNode->Advertise<msgs::ImageStamped>(
-          rsTopicRoot + COLOR_CAMERA_TOPIC, 1, DEPTH_PUB_FREQ_HZ);
+          rsTopicRoot + COLOR_CAMERA_TOPIC, 1, COLOR_PUB_FREQ_HZ);
 
   // Listen to depth camera new frame event
-  this->newDepthFrameConn = this->depthCam->ConnectNewDepthFrame(
-      std::bind(&RealSensePlugin::OnNewDepthFrame, this));
+  this->newDepthFrameConn = 
+      this->depthCam->ConnectNewDepthFrame(
+          std::bind(&RealSensePlugin::OnNewDepthFrame, this, &this->depthMap, 
+                    this->depthCam, this->depthPub));
+
+  this->newDepthRegisteredFrameConn = 
+      this->depthRegisteredCam->ConnectNewDepthFrame(
+          std::bind(&RealSensePlugin::OnNewDepthFrame, this, &this->depthRegisteredMap, 
+                    this->depthRegisteredCam, this->depthRegisteredPub));
 
   this->newIred1FrameConn =
       this->ired1Cam->ConnectNewImageFrame(
@@ -200,17 +231,19 @@ void RealSensePlugin::OnNewFrame(const rendering::CameraPtr cam,
 }
 
 /////////////////////////////////////////////////
-void RealSensePlugin::OnNewDepthFrame()
+void RealSensePlugin::OnNewDepthFrame(std::vector<uint16_t> *depth_map,
+                                      const rendering::DepthCameraPtr cam,
+                                      const transport::PublisherPtr pub)
 {
   // Get Depth Map dimensions
-  unsigned int imageSize = this->depthCam->ImageWidth() *
-                           this->depthCam->ImageHeight();
+  unsigned int imageSize = cam->ImageWidth() *
+                           cam->ImageHeight();
 
   // Instantiate message
   msgs::ImageStamped msg;
 
   // Convert Float depth data to RealSense depth data
-  const float *depthDataFloat = this->depthCam->DepthData();
+  const float *depthDataFloat = cam->DepthData();
   for (unsigned int i = 0; i < imageSize; ++i)
   {
     // Check clipping and overflow
@@ -219,11 +252,11 @@ void RealSensePlugin::OnNewDepthFrame()
         depthDataFloat[i] > DEPTH_SCALE_M * UINT16_MAX ||
         depthDataFloat[i] < 0)
     {
-      this->depthMap[i] = 0;
+      (*depth_map)[i] = 0;
     }
     else
     {
-      this->depthMap[i] = (uint16_t)(depthDataFloat[i] / DEPTH_SCALE_M);
+      (*depth_map)[i] = (uint16_t)(depthDataFloat[i] / DEPTH_SCALE_M);
     }
   }
 
@@ -233,17 +266,17 @@ void RealSensePlugin::OnNewDepthFrame()
 #else
   msgs::Set(msg.mutable_time(), this->world->GetSimTime());
 #endif
-  msg.mutable_image()->set_width(this->depthCam->ImageWidth());
-  msg.mutable_image()->set_height(this->depthCam->ImageHeight());
+  msg.mutable_image()->set_width(cam->ImageWidth());
+  msg.mutable_image()->set_height(cam->ImageHeight());
   msg.mutable_image()->set_pixel_format(common::Image::L_INT16);
-  msg.mutable_image()->set_step(this->depthCam->ImageWidth() *
-                                this->depthCam->ImageDepth());
+  msg.mutable_image()->set_step(cam->ImageWidth() *
+                                cam->ImageDepth());
   msg.mutable_image()->set_data(
-      this->depthMap.data(),
-      sizeof(*this->depthMap.data()) * imageSize);
+      depth_map->data(),
+      sizeof(*depth_map->data()) * imageSize);
 
   // Publish realsense scaled depth map
-  this->depthPub->Publish(msg);
+  pub->Publish(msg);
 }
 
 /////////////////////////////////////////////////

--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -46,6 +46,7 @@ void GazeboRosRealsense::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   this->ir1_pub_ = this->itnode_->advertiseCamera("camera/ir/image_raw", 2);
   this->ir2_pub_ = this->itnode_->advertiseCamera("camera/ir2/image_raw", 2);
   this->depth_pub_ = this->itnode_->advertiseCamera("camera/depth/image_raw", 2);
+  this->depth_registered_pub_ = this->itnode_->advertiseCamera("camera/depth_registered/image_raw", 2);
 }
 
 void GazeboRosRealsense::OnNewFrame(const rendering::CameraPtr cam,
@@ -97,7 +98,9 @@ void GazeboRosRealsense::OnNewFrame(const rendering::CameraPtr cam,
   image_pub->publish(this->image_msg_, camera_info_msg);
 }
 
-void GazeboRosRealsense::OnNewDepthFrame()
+void GazeboRosRealsense::OnNewDepthFrame(std::vector<uint16_t> *depth_map,
+                                         const rendering::DepthCameraPtr cam,
+                                         const transport::PublisherPtr pub)
 {
   // get current time
 #if GAZEBO_MAJOR_VERSION >= 9
@@ -106,7 +109,14 @@ void GazeboRosRealsense::OnNewDepthFrame()
   common::Time current_time = this->world->GetSimTime();
 #endif
 
-  RealSensePlugin::OnNewDepthFrame();
+  // identify camera
+  std::string camera_id = extractCameraName(cam->Name());
+  const std::map<std::string, image_transport::CameraPublisher*> camera_publishers = {
+    {DEPTH_CAMERA_NAME, &(this->depth_pub_)},
+    {DEPTH_REGISTERED_CAMERA_NAME, &(this->depth_registered_pub_)},
+  };
+  const auto image_pub = camera_publishers.at(camera_id);
+  RealSensePlugin::OnNewDepthFrame(depth_map, cam, pub);
 
   // copy data into image
   this->depth_msg_.header.frame_id = prefix+COLOR_CAMERA_NAME;
@@ -119,13 +129,13 @@ void GazeboRosRealsense::OnNewDepthFrame()
   // copy from simulation image to ROS msg
   fillImage(this->depth_msg_,
     pixel_format,
-    this->depthCam->ImageHeight(), this->depthCam->ImageWidth(),
-    2 * this->depthCam->ImageWidth(),
-    reinterpret_cast<const void*>(this->depthMap.data()));
+    cam->ImageHeight(), cam->ImageWidth(),
+    2 * cam->ImageWidth(),
+    reinterpret_cast<const void*>(depth_map->data()));
 
   // publish to ROS
-  auto depth_info_msg = cameraInfo(this->depth_msg_, this->depthCam->HFOV().Radian());
-  this->depth_pub_.publish(this->depth_msg_, depth_info_msg);
+  auto depth_info_msg = cameraInfo(this->depth_msg_, cam->HFOV().Radian());
+  image_pub->publish(this->depth_msg_, depth_info_msg);
 }
 
 }
@@ -137,6 +147,8 @@ namespace
     if (name.find(COLOR_CAMERA_NAME) != std::string::npos) return COLOR_CAMERA_NAME;
     if (name.find(IRED1_CAMERA_NAME) != std::string::npos) return IRED1_CAMERA_NAME;
     if (name.find(IRED2_CAMERA_NAME) != std::string::npos) return IRED2_CAMERA_NAME;
+    if (name.find(DEPTH_REGISTERED_CAMERA_NAME) != std::string::npos) return DEPTH_REGISTERED_CAMERA_NAME; // needs to be checked before regular depth
+    if (name.find(DEPTH_CAMERA_NAME) != std::string::npos) return DEPTH_CAMERA_NAME;
 
     ROS_ERROR("Unknown camera name");
     return COLOR_CAMERA_NAME;

--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -46,7 +46,9 @@ void GazeboRosRealsense::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   this->ir1_pub_ = this->itnode_->advertiseCamera("camera/ir/image_raw", 2);
   this->ir2_pub_ = this->itnode_->advertiseCamera("camera/ir2/image_raw", 2);
   this->depth_pub_ = this->itnode_->advertiseCamera("camera/depth/image_raw", 2);
-  this->depth_registered_pub_ = this->itnode_->advertiseCamera("camera/depth_registered/image_raw", 2);
+  if(RealSensePlugin::depthRegisteredCam) {
+    this->depth_registered_pub_ = this->itnode_->advertiseCamera("camera/depth_registered/image_raw", 2);
+  }
 }
 
 void GazeboRosRealsense::OnNewFrame(const rendering::CameraPtr cam,


### PR DESCRIPTION
Adding another depth image stream in order to allow adding a registered depth camera, which obtains corresponding depth information for each point in an RGB image. Removes the necessity for manually registering depth images to RGB cameras in simulation, instead just another depth sensor can be added with the same parameters as the RGB camera.